### PR TITLE
Update bindgen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ build = "build.rs"
 categories = ["external-ffi-bindings"]
 
 [build-dependencies]
-bindgen = "0.55.1"
+bindgen = "0.53"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ build = "build.rs"
 categories = ["external-ffi-bindings"]
 
 [build-dependencies]
-bindgen = "~0.40"
+bindgen = "0.55.1"


### PR DESCRIPTION
This crate have old version of `bindgen`. Old version of `bindgen` depends on old version of `clang-sys`. Clang-sys is a native library and can't be linked twice with different versions, but we already have another version of `clang-sys` in elastio
```
error: multiple packages link to native library `clang`, but a native library can be linked only once

package `clang-sys v0.22.0`
    ... which is depended on by `bindgen v0.33.2`
    ... which is depended on by `blkid-sys v0.1.3`
    ... which is depended on by `blkid v0.2.1`
    ... which is depended on by `viy v0.1.0 (/home/nikbond/elastiosw/elastio/viy)`
links to native library `clang`

package `clang-sys v0.29.3`
    ... which is depended on by `bindgen v0.53.3`
    ... which is depended on by `btrfs-sys v0.1.0 (/home/nikbond/elastiosw/elastio/viy/btrfs-sys)`
    ... which is depended on by `viy v0.1.0 (/home/nikbond/elastiosw/elastio/viy)`
also links to native library `clang`

```

So I've forked this crate and update `bindgen` version to 0.53. Note: I can't update `bindgen` to latest 0.55 according [to this comment](https://github.com/elastio/elastio/pull/484#issuecomment-686300623)

Also I've forked [overlying crate `blkid`](https://github.com/elastio/blkid) and created PR to update `blkid-sys` to this forked version